### PR TITLE
fix: fix the crash when relinking manifests on Windows systems using a non-UTF-8 default locale

### DIFF
--- a/src/game_data.py
+++ b/src/game_data.py
@@ -132,7 +132,7 @@ class GameDataManager:
     def update_manifest_location_references(self, launcher_manifest: FileDirectory, updated_game_folder: str) -> None:
         
         # Open file as read/write
-        with open(launcher_manifest.path, 'r+') as file:
+        with open(launcher_manifest.path, 'r+', encoding='utf-8') as file:
             data = json.load(file)
 
             # Check version


### PR DESCRIPTION
  ## Problem
  `json.load(file)` failed with:

  `UnicodeDecodeError: 'gbk' codec can't decode byte 0x8b ...`

  The failure happened in `GameDataManager.update_manifest_location_references()` when opening the launcher manifest.

  ## Root Cause
  The file was opened without an explicit encoding, so Python used the system default encoding (GBK on
  this machine), while the manifest content is UTF-8.

  ## Fix
  Updated manifest file opening logic in `src/game_data.py` to explicitly use UTF-8:

  - from: `open(launcher_manifest.path, 'r+')`
  - to: `open(launcher_manifest.path, 'r+', encoding='utf-8')`

  ## Impact
  - Prevents locale-dependent decoding failures.
  - Keeps behavior unchanged for valid UTF-8 manifest files.
  - Relinking flow now works consistently across different Windows locale settings.